### PR TITLE
used v2 user endoint instead of v1

### DIFF
--- a/server/commands_account.go
+++ b/server/commands_account.go
@@ -47,7 +47,7 @@ func (p *Plugin) executeAccount(args *model.CommandArgs, circleciToken string, s
 }
 
 func (p *Plugin) executeAccountView(args *model.CommandArgs, token string) (*model.CommandResponse, *model.AppError) {
-	user, ok := p.getCircleUserInfo(token)
+	user, ok := getCurrentUser(token)
 	if !ok {
 		p.API.LogInfo("Unable to get CircleCI info", "MM UserID", args.UserId)
 		return p.sendEphemeralResponse(args, errorConnectionText), nil
@@ -98,7 +98,7 @@ func (p *Plugin) executeAccountConnect(args *model.CommandArgs, split []string) 
 	}
 
 	if token, exists := p.getTokenKV(args.UserId); exists {
-		user, ok := p.getCircleUserInfo(token)
+		user, ok := getCurrentUser(token)
 		if !ok {
 			return p.sendEphemeralResponse(args, "Internal error when reaching CircleCI"), nil
 		}


### PR DESCRIPTION
## Changes

<!-- List all the changes made to the code. Add unticked items if some work has to be done -->

- [x] MIgrated get current user calls to v2
- [ ] Update README.md

## Changelog


```
## New features
- /

## Enhancements
- migrated get user to v2 client

## Bug Fixes and Others
- /
```
